### PR TITLE
Remove trailing slashes from rspace_url

### DIFF
--- a/rspace_client/client_base.py
+++ b/rspace_client/client_base.py
@@ -31,7 +31,7 @@ class ClientBase:
         Initializes RSpace client.
         :param api_key: RSpace API key of a user can be found on 'My Profile' page
         """
-        self.rspace_url = rspace_url
+        self.rspace_url = rspace_url.rstrip('/')
         self.api_key = api_key
 
     def _get_headers(self, content_type="application/json"):


### PR DESCRIPTION
A trailing slash causes problems when retrieving further results via get_link_contents through retrieve_api_results, while initially the connecting and getting the first page of documents worked. Stripping trailing slashes makes this code more robust, e.g. in case of copy/pasting URLs from the browser.