### PR TITLE
Automatically convert integer IDs to strings and join with comma to a…

### DIFF
--- a/rspace_client/eln/eln.py
+++ b/rspace_client/eln/eln.py
@@ -469,7 +469,7 @@ class ELNClient(ClientBase):
         :return: job id
         """
         self._check_export_format(export_format)
-        itemsToExport = "".join(item_ids)
+        itemsToExport = ",".join(map(str, item_ids))
         request_url = (
             self._get_api_url()
             + f"/export/{export_format}/selection?selections={itemsToExport}&includeRevisionHistory={include_revisions}"


### PR DESCRIPTION
…llow multiple selection.

Previously retrieved document IDs are parsed as integers, which need string conversion for further download_export_selection calls. This is now done automatically, so that download_export_selection also takes integer lists as inputs. Additionally, multiple selections have to be comma separated, which is fixed with this commit.