### PR TITLE
Sample barcodes support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ ENV/
 # Rope project settings
 .ropeproject
 .idea/
+.vscode/
 #*.log
 examples/deletedUserslog.txt
 .spyproject/

--- a/examples/create_sample.py
+++ b/examples/create_sample.py
@@ -5,8 +5,8 @@ Created on Mon Oct 18 20:23:16 2021
 
 @author: richard
 """
-
 import rspace_client
+from rspace_client.inv.inv import Barcode, BarcodeFormat
 
 inv_api = rspace_client.utils.createInventoryClient()
 
@@ -15,4 +15,28 @@ print("Creating a sample")
 sample = inv_api.create_sample("My first sample")
 print(
     f"Sample with id {sample['id']} was created with {len(sample['subSamples'])} subsamples"
+)
+
+
+barcodes = [
+    Barcode(
+        data="https://researchspace.com",
+        format=BarcodeFormat.BARCODE,
+        description="ResearchSpace"
+    ),
+    Barcode(
+        data="https://www.wikipedia.org/",
+        format=BarcodeFormat.BARCODE,
+        description="Wikipedia"
+    )
+]
+
+# Convert to dicts
+barcode_dicts = [barcode.to_dict() for barcode in barcodes]
+sample_with_barcode = inv_api.create_sample("sampleWithBarcodes", barcodes=barcodes)
+
+print(
+    f"Sample with id {sample_with_barcode['id']} was created with "
+    f"{len(sample_with_barcode['subSamples'])} subsamples and "
+    f"{len(sample_with_barcode.get('barcodes', []))} barcodes"
 )

--- a/examples/create_sample.py
+++ b/examples/create_sample.py
@@ -18,6 +18,8 @@ print(
 )
 
 
+print("Creating a sample with barcodes")
+
 barcodes = [
     Barcode(
         data="https://researchspace.com",


### PR DESCRIPTION
- Should be able to close [issue](https://github.com/rspace-os/rspace-client-python/issues/35), once this PR is reviewed.
- Our current Swagger [definition](https://pangolin8086.researchspace.com/public/apiDocs?urls.primaryName=RSpace%20Inventory) for the `Barcode` object  seems to be out-of-date 
      - The `format` field is marked as optional, but in practice, it is required when creating a barcode via the API (`'BARCODE'` must be provided).
      - The `newBarcodeRequest` field is missing entirely from the schema, even though it's **required** for creating new barcodes (e.g. `"newBarcodeRequest": true`).